### PR TITLE
Add Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -22,7 +22,7 @@ If you believe someone is violating the Code of Conduct, we ask that you report 
 
 ##### Part 1. Introduction
 
-The Research Support Network is led by a small number of computational scientists and runs the Expert Volunteer List. Anyone can sign up to the list and contributions to the list's open source backend via GitHub are welcome. We value the involvement of everyone contributing and utilizing the list and are committed to creating a friendly and respectful environment for anyone participating in list-related activities. All participants are expected to show respect and courtesy to others.
+The Research Support Network is led by a small number of computational scientists and runs the Expert Volunteer List. We encourage anyone with computational expertise to sign up to the list if they have the capacity to provide virtual support and advice for scientists forced to refocus on computational work due to a crisis. Contributions to the list's open source backend via GitHub are also welcome. We value the involvement of everyone contributing and utilizing the list and are committed to creating a friendly and respectful environment for anyone participating in list-related activities. All participants are expected to show respect and courtesy to others.
 
 To make clear what is expected, participants in list-related activities activities are expected to conform to the Code of Conduct. This Code of Conduct applies to all spaces related to the Expert Volunteer List, including, but not limited to, the private interactions between expert volunteers and scientists seeking support, the list entry submission form, the project's GitHub repository, list-related email, and list-related discussion in other public forums.
 
@@ -42,6 +42,8 @@ All participants in list-related activities are expected to show respect and cou
 * Be respectful of different viewpoints and experiences
 * Gracefully accept constructive criticism
 * Show courtesy and respect towards others
+
+Experts should also be mindful of the fact that scientists seeking support may be living through (or have recently lived through) extremely traumatic experiences. Be considerate and avoid bringing up topics that may cause anxiety. Conversely, be prepared for the possibility of hearing accounts that could be disturbing. We recommend focusing on the science and if necessary setting clear boundaries on other topics.
 
 ##### Part 2.2. Unacceptable behaviour
 
@@ -73,4 +75,4 @@ Equally, if anyone violates this Code of Conduct in interactions with the list's
 
 #### About this Document
 
-This document is derived from the [Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) (retrieved 2022-03-12, Copyright © [The Carpentries](https://carpentries.org), used under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)). It has been amended and simplified in accordance with the small scope of the Expert Volunteer List. The initial contributors to this Code of Conduct were Jonas Hartmann and <font color=red>(...)</font>.
+This document is derived from the [Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) (retrieved 2022-03-12, Copyright © [The Carpentries](https://carpentries.org), used under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)). It has been amended and simplified in accordance with the small scope of the Expert Volunteer List. The initial contributors to this Code of Conduct were Jonas Hartmann, Elisabeth Kugler and <font color=red>(...)</font>.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -16,7 +16,7 @@ The Research Support Network is dedicated to providing a welcoming and supportiv
 * Gracefully accept constructive criticism
 * Show courtesy and respect towards others
 
-If you believe someone is violating the Code of Conduct, we ask that you report it to the list's maintainers using <font color=red>(this email)</font>. Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice, as the list is run purely as an "address book" and the list's maintainers are not in a position to investigate reported violations or to mediate conflicts within the private interactions between expert volunteers and scientists seeking support.
+If you believe someone is violating the Code of Conduct, we ask that you report it to the list's maintainers via email to [expertvolunteerlist@gmail.com](expertvolunteerlist@gmail.com). Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice, as the list is run purely as an "address book" and the list's maintainers are not in a position to investigate reported violations or to mediate conflicts within the private interactions between expert volunteers and scientists seeking support.
 
 #### Code of Conduct (Detailed View)
 
@@ -26,7 +26,7 @@ The Research Support Network is led by a small number of computational scientist
 
 To make clear what is expected, participants in list-related activities activities are expected to conform to the Code of Conduct. This Code of Conduct applies to all spaces related to the Expert Volunteer List, including, but not limited to, the private interactions between expert volunteers and scientists seeking support, the list entry submission form, the project's GitHub repository, list-related email, and list-related discussion in other public forums.
 
-The list's maintainers uphold the Code of Conduct and can be contacted at <font color=red>(email)</font>. All reports will be treated with confidentiality. Any report of a volunteer expert violating the code will lead to their removal from the list. The list's maintainers are not able to offer and explicitly dislaim all other forms of mediation or arbitration.
+The list's maintainers uphold the Code of Conduct and can be contacted by [email](expertvolunteerlist@gmail.com). All reports will be treated with confidentiality. Any report of a volunteer expert violating the code will lead to their removal from the list. The list's maintainers are not able to offer and explicitly dislaim all other forms of mediation or arbitration.
 
 ##### Part 2. Expert Volunteer List - Code of Conduct
 
@@ -61,7 +61,7 @@ Examples of unacceptable behaviour by participants in any list-related activites
 
 ##### Part 2.3. Consequences of Unacceptable behaviour
 
-Participants who are asked to stop any inappropriate behaviour are expected to comply immediately. This applies to all list-related activities on any platform. If an expert volunteer or scientist seeking support engages in behaviour that violates this Code of Conduct, their counterpart may warn the offender, terminate the interaction, and/or inform the list's maintainers via this <font color=red>(email)</font>. 
+Participants who are asked to stop any inappropriate behaviour are expected to comply immediately. This applies to all list-related activities on any platform. If an expert volunteer or scientist seeking support engages in behaviour that violates this Code of Conduct, their counterpart may warn the offender, terminate the interaction, and/or inform the list's maintainers via email to [expertvolunteerlist@gmail.com](expertvolunteerlist@gmail.com). 
 
 Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice, as the list is run purely as an "address book" and the list's maintainers are not in a position to investigate reported violations or to mediate conflicts arising in the private interactions between expert volunteers and scientists seeking support.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,76 @@
+---
+title: Code of Conduct
+layout: default
+---
+
+**<font color=red>[DRAFT!]</font>**
+
+### Research Support Network - Expert Volunteer List - Code of Conduct
+
+#### Code of Conduct (Summary View)
+
+The Research Support Network is dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity. By signing up to the Expert Volunteer List or by using it to contact an expert volunteer, participants accept to abide by this Code of Conduct and accept the procedures by which any Code of Conduct incidents are resolved. Any form of behaviour to exclude, intimidate, or cause discomfort is a violation of the Code of Conduct. In order to foster a positive and professional environment we encourage the following kinds of behaviours in all interactions:
+
+* Use welcoming and inclusive language
+* Be respectful of different viewpoints and experiences
+* Gracefully accept constructive criticism
+* Show courtesy and respect towards others
+
+If you believe someone is violating the Code of Conduct, we ask that you report it to the list's maintainers using <font color=red>(this email)</font>. Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice, as the list is run purely as an "address book" and the list's maintainers are not in a position to investigate reported violations or to mediate conflicts within the private interactions between expert volunteers and scientists seeking support.
+
+#### Code of Conduct (Detailed View)
+
+##### Part 1. Introduction
+
+The Research Support Network is led by a small number of computational scientists and runs the Expert Volunteer List. Anyone can sign up to the list and contributions to the list's open source backend via GitHub are welcome. We value the involvement of everyone contributing and utilizing the list and are committed to creating a friendly and respectful environment for anyone participating in list-related activities. All participants are expected to show respect and courtesy to others.
+
+To make clear what is expected, participants in list-related activities activities are expected to conform to the Code of Conduct. This Code of Conduct applies to all spaces related to the Expert Volunteer List, including, but not limited to, the private interactions between expert volunteers and scientists seeking support, the list entry submission form, the project's GitHub repository, list-related email, and list-related discussion in other public forums.
+
+The list's maintainers uphold the Code of Conduct and can be contacted at <font color=red>(email)</font>. All reports will be treated with confidentiality. Any report of a volunteer expert violating the code will lead to their removal from the list. The list's maintainers are not able to offer and explicitly dislaim all other forms of mediation or arbitration.
+
+##### Part 2. Expert Volunteer List - Code of Conduct
+
+The Research Support Network is dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity. As such, we do not tolerate behaviour that is disrespectful to anyone involved in list-related activities or that excludes, intimidates, or causes discomfort to others. We do not tolerate discrimination or harassment based on characteristics that include, but are not limited to, gender identity and expression, sexual orientation, disability, physical appearance, body size, citizenship, nationality, ethnic or social origin, pregnancy, familial status, veteran status, genetic information, religion or belief (or lack thereof), membership of a national minority, property, age, education, socio-economic status, technical choices, and experience level. 
+
+Everyone who participates in list-related activities is required to conform to this Code of Conduct. It applies to all spaces related to the Expert Volunteer List, including, but not limited to, the private interactions between expert volunteers and scientists seeking support, the list entry submission form, the project's GitHub repository, list-related email, and list-related discussion in other public forums. By participating, participants indicate their acceptance of the procedures by which the list's maintainers resolve any Code of Conduct incidents, which may include storage and processing of their list-related information. 
+
+##### Part 2.1. Expected behaviour
+
+All participants in list-related activities are expected to show respect and courtesy to others. All interactions should be professional regardless of platform. In order to foster a positive and professional  environment we encourage the following kinds of behaviours in interactions:
+
+* Use welcoming and inclusive language
+* Be respectful of different viewpoints and experiences
+* Gracefully accept constructive criticism
+* Show courtesy and respect towards others
+
+##### Part 2.2. Unacceptable behaviour
+
+Examples of unacceptable behaviour by participants in any list-related activites include:
+
+- written or verbal comments which have the effect of excluding people on the basis of membership of any specific group  
+- causing someone to fear for their safety, such as through stalking, following, or intimidation  
+- violent threats or language directed against another person
+- the display of sexual or violent images  
+- unwelcome sexual attention or contact of any form
+- insults or put downs  
+- sexist, racist, homophobic, transphobic, ableist, or exclusionary jokes
+- excessive swearing
+- incitement to violence, suicide, or self-harm  
+- continuing to initiate interaction with someone after being asked to stop  
+- publication of private communication without consent  
+
+##### Part 2.3. Consequences of Unacceptable behaviour
+
+Participants who are asked to stop any inappropriate behaviour are expected to comply immediately. This applies to all list-related activities on any platform. If an expert volunteer or scientist seeking support engages in behaviour that violates this Code of Conduct, their counterpart may warn the offender, terminate the interaction, and/or inform the list's maintainers via this <font color=red>(email)</font>. 
+
+Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice, as the list is run purely as an "address book" and the list's maintainers are not in a position to investigate reported violations or to mediate conflicts arising in the private interactions between expert volunteers and scientists seeking support.
+
+Equally, if anyone violates this Code of Conduct in interactions with the list's maintainers on any platform, e.g. on GitHub or through email, the maintainers may warn them, may ban them from participation in relevant online spaces, may report them to relevant platform holders if they are in breach of the platform's Code of Conduct, and in the case of expert volunteers may remove their entry from the list.
+
+#### Update Logs
+
+- <font color=red>2022-03-??</font> Code of Conduct released. 
+
+#### About this Document
+
+This document is derived from the [Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) (retrieved 2022-03-12, Copyright © [The Carpentries](https://carpentries.org), used under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)). It has been amended and simplified in accordance with the small scope of the Expert Volunteer List. The initial contributors to this Code of Conduct were Jonas Hartmann and <font color=red>(...)</font>.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -16,7 +16,7 @@ The Research Support Network is dedicated to providing a welcoming and supportiv
 * Gracefully accept constructive criticism
 * Show courtesy and respect towards others
 
-If you believe someone is violating the Code of Conduct, we ask that you report it to the list's maintainers via email to [expertvolunteerlist@gmail.com](expertvolunteerlist@gmail.com). Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice, as the list is run purely as an "address book" and the list's maintainers are not in a position to investigate reported violations or to mediate conflicts within the private interactions between expert volunteers and scientists seeking support.
+If you believe someone is violating the Code of Conduct, we ask that you report it to the list's maintainers via email to [expertvolunteerlist@gmail.com](expertvolunteerlist@gmail.com). Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice. Scientists seeking support who are reported to have violated the Code of Conduct will have their names made known to listed experts via an opt-in mailing list, again without investigation or notice. We recommend that experts do not engage with reported participants. The list's maintainers are not in a position to investigate reported violations, to arbitrate disputes or appeals, or to mediate conflicts arising within the private interactions between expert volunteers and scientists seeking support.
 
 #### Code of Conduct (Detailed View)
 
@@ -26,7 +26,7 @@ The Research Support Network is led by a small number of computational scientist
 
 To make clear what is expected, participants in list-related activities activities are expected to conform to the Code of Conduct. This Code of Conduct applies to all spaces related to the Expert Volunteer List, including, but not limited to, the private interactions between expert volunteers and scientists seeking support, the list entry submission form, the project's GitHub repository, list-related email, and list-related discussion in other public forums.
 
-The list's maintainers uphold the Code of Conduct and can be contacted by [email](expertvolunteerlist@gmail.com). All reports will be treated with confidentiality. Any report of a volunteer expert violating the code will lead to their removal from the list. The list's maintainers are not able to offer and explicitly dislaim all other forms of mediation or arbitration.
+The list's maintainers uphold the Code of Conduct and can be contacted by [email](expertvolunteerlist@gmail.com). All reports will be treated with confidentiality. Any report of a volunteer expert violating the code will lead to their removal from the list. Any report of a scientist seeking support violating the code will lead to their name being made known to the expert volunteers via an opt-in mailing list. We recommend that experts do not engage with reported participants. The list's maintainers are not able to offer and explicitly dislaim all other forms of mediation or arbitration.
 
 ##### Part 2. Expert Volunteer List - Code of Conduct
 
@@ -65,9 +65,9 @@ Examples of unacceptable behaviour by participants in any list-related activites
 
 Participants who are asked to stop any inappropriate behaviour are expected to comply immediately. This applies to all list-related activities on any platform. If an expert volunteer or scientist seeking support engages in behaviour that violates this Code of Conduct, their counterpart may warn the offender, terminate the interaction, and/or inform the list's maintainers via email to [expertvolunteerlist@gmail.com](expertvolunteerlist@gmail.com). 
 
-Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice, as the list is run purely as an "address book" and the list's maintainers are not in a position to investigate reported violations or to mediate conflicts arising in the private interactions between expert volunteers and scientists seeking support.
+Expert volunteers who are reported to have violated the Code of Conduct will be removed from the Expert Volunteer List without investigation or notice. Scientists seeking support who are reported to have violated the Code of Conduct will have their names made known to listed experts via an opt-in mailing list, again without investigation or notice. We recommend that experts do not engage with reported participants. Beyond these measures, the list's maintainers are not in a position to investigate reported violations, to arbitrate disputes or appeals, or to mediate conflicts arising within the private interactions between expert volunteers and scientists seeking support.
 
-Equally, if anyone violates this Code of Conduct in interactions with the list's maintainers on any platform, e.g. on GitHub or through email, the maintainers may warn them, may ban them from participation in relevant online spaces, may report them to relevant platform holders if they are in breach of the platform's Code of Conduct, and in the case of expert volunteers may remove their entry from the list.
+If anyone violates this Code of Conduct in interactions with the list's maintainers on any platform, e.g. on GitHub or through email, the maintainers may warn them, may ban them from participation in relevant online spaces, may report them to relevant platform holders if they are in breach of the platform's Code of Conduct, in the case of expert volunteers may remove their entry from the list, and in the case of scientists seeking support may make their name known to the experts.
 
 #### Update Logs
 
@@ -75,4 +75,4 @@ Equally, if anyone violates this Code of Conduct in interactions with the list's
 
 #### About this Document
 
-This document is derived from the [Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) (retrieved 2022-03-12, Copyright © [The Carpentries](https://carpentries.org), used under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)). It has been amended and simplified in accordance with the small scope of the Expert Volunteer List. The initial contributors to this Code of Conduct were Jonas Hartmann, Elisabeth Kugler and <font color=red>(...)</font>.
+This document is derived from the [Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) (retrieved 2022-03-12, Copyright © [The Carpentries](https://carpentries.org), used under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)). It has been amended and simplified in accordance with the small scope of the Expert Volunteer List. The initial contributors to this Code of Conduct were Jonas Hartmann, Elisabeth Kugler, Toby Hodges and Renato Alves.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -3,8 +3,6 @@ title: Code of Conduct
 layout: default
 ---
 
-**<font color=red>[DRAFT!]</font>**
-
 ### Research Support Network - Expert Volunteer List - Code of Conduct
 
 #### Code of Conduct (Summary View)
@@ -71,7 +69,7 @@ If anyone violates this Code of Conduct in interactions with the list's maintain
 
 #### Update Logs
 
-- <font color=red>2022-03-??</font> Code of Conduct released. 
+- 2022-03-17 Code of Conduct released. 
 
 #### About this Document
 


### PR DESCRIPTION
I've created a draft for the code of conduct by amending [the one from The Carpentries](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html), as suggested by @tobyhodges.

I would be very grateful if someone (ideally Toby?) could have a look and confirm that this is ok or suggest/add any changes before this is merged.

~I'll also see if I can sort out the contact email.~ (Done.)